### PR TITLE
scripts: add deploy-local.sh to deploy builds to ~/.openclaw/

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,6 +224,8 @@
     "android:run": "cd apps/android && ./gradlew :app:installDebug && adb shell am start -n ai.openclaw.app/.MainActivity",
     "android:test": "cd apps/android && ./gradlew :app:testDebugUnitTest",
     "android:test:integration": "OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_ANDROID_NODE=1 vitest run --config vitest.live.config.ts src/gateway/android-node.capabilities.live.test.ts",
+    "deploy:local": "bash scripts/deploy-local.sh",
+    "deploy:local:fast": "OPENCLAW_DEPLOY_SKIP_TESTS=1 bash scripts/deploy-local.sh",
     "build": "pnpm canvas:a2ui:bundle && node scripts/tsdown-build.mjs && node scripts/copy-plugin-sdk-root-alias.mjs && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-startup-metadata.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:docker": "node scripts/tsdown-build.mjs && node scripts/copy-plugin-sdk-root-alias.mjs && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-startup-metadata.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json || true",

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Authored by: cc (Claude Code) | 2026-03-15
+# Deploy a successful local build to ~/.openclaw/ so the LaunchAgent
+# runs from a stable deployed copy instead of the live repo dist/.
+#
+# Usage:
+#   pnpm deploy:local                      # build + test + deploy + restart
+#   OPENCLAW_DEPLOY_SKIP_TESTS=1 pnpm deploy:local   # skip tests
+#   OPENCLAW_DEPLOY_SKIP_RESTART=1 pnpm deploy:local # skip gateway restart
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEPLOY_DIR="${HOME}/.openclaw"
+DIST_SRC="${REPO_DIR}/dist"
+DIST_DEST="${DEPLOY_DIR}/dist"
+SKIP_TESTS="${OPENCLAW_DEPLOY_SKIP_TESTS:-0}"
+SKIP_RESTART="${OPENCLAW_DEPLOY_SKIP_RESTART:-0}"
+LAUNCHD_LABEL="ai.openclaw.gateway"
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
+NODE_MODULES_DEST="${DEPLOY_DIR}/node_modules"
+SKILLS_DEST="${DEPLOY_DIR}/skills"
+OPENCLAW_MJS_DEST="${DEPLOY_DIR}/openclaw.mjs"
+
+log() { printf '[deploy-local] %s\n' "$*"; }
+die() { printf '[deploy-local] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# ── 1. Build ──────────────────────────────────────────────────────────────────
+log "Building..."
+cd "${REPO_DIR}"
+pnpm build
+
+# ── 2. Tests (optional) ───────────────────────────────────────────────────────
+if [[ "${SKIP_TESTS}" != "1" ]]; then
+  log "Running tests..."
+  pnpm test:fast
+else
+  log "Skipping tests (OPENCLAW_DEPLOY_SKIP_TESTS=1)"
+fi
+
+# ── 3. node_modules symlink ───────────────────────────────────────────────────
+# The bundled dist/ files still resolve npm packages via Node's ancestor
+# node_modules lookup. We symlink ~/.openclaw/node_modules → repo node_modules
+# so resolution works without copying 1.5 GB.
+if [[ -L "${NODE_MODULES_DEST}" ]]; then
+  CURRENT_LINK="$(readlink "${NODE_MODULES_DEST}")"
+  if [[ "${CURRENT_LINK}" != "${REPO_DIR}/node_modules" ]]; then
+    log "Updating node_modules symlink (was: ${CURRENT_LINK})"
+    rm "${NODE_MODULES_DEST}"
+    ln -s "${REPO_DIR}/node_modules" "${NODE_MODULES_DEST}"
+  else
+    log "node_modules symlink already correct"
+  fi
+elif [[ -d "${NODE_MODULES_DEST}" ]]; then
+  log "Backing up existing node_modules → node_modules.pre-deploy"
+  mv "${NODE_MODULES_DEST}" "${DEPLOY_DIR}/node_modules.pre-deploy"
+  ln -s "${REPO_DIR}/node_modules" "${NODE_MODULES_DEST}"
+  log "node_modules symlink created (backup saved)"
+else
+  ln -s "${REPO_DIR}/node_modules" "${NODE_MODULES_DEST}"
+  log "node_modules symlink created"
+fi
+
+# ── 4. skills symlink ─────────────────────────────────────────────────────────
+# resolveOpenClawPackageRootSync looks for skills/ under the package root.
+# Symlink so bundled skills resolve without copying.
+if [[ ! -e "${SKILLS_DEST}" ]]; then
+  ln -s "${REPO_DIR}/skills" "${SKILLS_DEST}"
+  log "skills symlink created"
+elif [[ -L "${SKILLS_DEST}" ]]; then
+  log "skills symlink already exists"
+else
+  log "WARNING: ${SKILLS_DEST} exists and is not a symlink — leaving it alone"
+fi
+
+# ── 5. Patch ~/.openclaw/package.json ─────────────────────────────────────────
+# resolveOpenClawPackageRootSync() walks ancestor dirs looking for a package.json
+# with "name": "openclaw". Without this field the runtime can't find skills/
+# or control-ui assets when running from ~/.openclaw/dist/.
+PKGJSON="${DEPLOY_DIR}/package.json"
+if [[ -f "${PKGJSON}" ]]; then
+  CURRENT_NAME="$(jq -r '.name // empty' "${PKGJSON}")"
+  if [[ "${CURRENT_NAME}" != "openclaw" ]]; then
+    TMPFILE="$(mktemp)"
+    jq '. + {"name": "openclaw"}' "${PKGJSON}" > "${TMPFILE}"
+    mv "${TMPFILE}" "${PKGJSON}"
+    log "Added \"name\": \"openclaw\" to ${PKGJSON}"
+  else
+    log "package.json name already set"
+  fi
+else
+  printf '{"name":"openclaw","type":"module"}\n' > "${PKGJSON}"
+  log "Created minimal ${PKGJSON}"
+fi
+
+# ── 6. rsync dist/ ────────────────────────────────────────────────────────────
+log "Deploying dist/ → ${DIST_DEST}..."
+mkdir -p "${DIST_DEST}"
+rsync -a --delete "${DIST_SRC}/" "${DIST_DEST}/"
+log "dist/ deployed"
+
+# ── 7. Copy openclaw.mjs ──────────────────────────────────────────────────────
+cp "${REPO_DIR}/openclaw.mjs" "${OPENCLAW_MJS_DEST}"
+log "openclaw.mjs copied"
+
+# ── 8. Update plist ───────────────────────────────────────────────────────────
+DESIRED_ENTRY="${DIST_DEST}/index.js"
+if [[ ! -f "${PLIST_PATH}" ]]; then
+  log "WARNING: plist not found at ${PLIST_PATH} — skipping plist update"
+else
+  CURRENT_ENTRY="$(/usr/bin/plutil -extract ProgramArguments.1 raw -o - "${PLIST_PATH}" 2>/dev/null || true)"
+  if [[ "${CURRENT_ENTRY}" != "${DESIRED_ENTRY}" ]]; then
+    log "Updating plist ProgramArguments[1]: ${CURRENT_ENTRY} → ${DESIRED_ENTRY}"
+    # Must unload before editing so launchd picks up the change on bootstrap
+    launchctl bootout "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null || true
+    /usr/bin/plutil -replace 'ProgramArguments.1' -string "${DESIRED_ENTRY}" "${PLIST_PATH}"
+    log "Plist updated"
+  else
+    log "Plist already points to correct entry"
+  fi
+fi
+
+# ── 9. Restart gateway ────────────────────────────────────────────────────────
+if [[ "${SKIP_RESTART}" != "1" ]]; then
+  log "Restarting gateway..."
+  launchctl bootout "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "${PLIST_PATH}"
+  sleep 2
+  log "Gateway restarted. Checking status..."
+  openclaw gateway status --deep || log "WARNING: gateway status check failed — check logs at ${DEPLOY_DIR}/logs/gateway.log"
+else
+  log "Skipping gateway restart (OPENCLAW_DEPLOY_SKIP_RESTART=1)"
+fi
+
+log "Deploy complete. Gateway running from ${DIST_DEST}/index.js"


### PR DESCRIPTION
## Summary

- Adds `scripts/deploy-local.sh` — a deploy orchestrator that rsyncs a successful build to `~/.openclaw/dist/` and updates the gateway LaunchAgent plist to run from there
- Adds `pnpm deploy:local` and `pnpm deploy:local:fast` npm scripts
- Decouples the live gateway from the repo `dist/` folder so builds and in-progress work no longer affect the running service

## Problem

The launchd gateway plist pointed directly at `~/Developer/openclaw/dist/index.js`. Any `pnpm build` immediately affected the running gateway, and a failed or mid-flight build could crash it. This change makes deploys explicit and atomic.

## What the script does

1. `pnpm build` in the repo
2. `pnpm test:fast` (skip with `OPENCLAW_DEPLOY_SKIP_TESTS=1`)
3. Symlinks `~/.openclaw/node_modules` → repo `node_modules/` (module resolution requires this; dist is not fully self-contained)
4. Symlinks `~/.openclaw/skills` → repo `skills/` (bundled skills resolution)
5. Patches `~/.openclaw/package.json` to add `"name": "openclaw"` (required by `resolveOpenClawPackageRootSync`)
6. `rsync -a --delete` repo `dist/` → `~/.openclaw/dist/`
7. Copies `openclaw.mjs` to `~/.openclaw/`
8. Updates plist `ProgramArguments[1]` to `~/.openclaw/dist/index.js` (via `plutil`)
9. Restarts the LaunchAgent and verifies with `openclaw gateway status --deep`

## Usage

```bash
pnpm deploy:local         # build + test + deploy + restart
pnpm deploy:local:fast    # skip tests
```

## Test plan

- [ ] `chmod +x scripts/deploy-local.sh`
- [ ] `pnpm deploy:local:fast` completes without error
- [ ] `ls -la ~/.openclaw/node_modules` → symlink to repo
- [ ] `ls -la ~/.openclaw/skills` → symlink to repo
- [ ] `jq .name ~/.openclaw/package.json` → `"openclaw"`
- [ ] `plutil -extract ProgramArguments.1 raw ~/Library/LaunchAgents/ai.openclaw.gateway.plist` → `~/.openclaw/dist/index.js`
- [ ] `openclaw gateway status --deep` passes
- [ ] `tail -20 ~/.openclaw/logs/gateway.log` — no `ERR_MODULE_NOT_FOUND`
- [ ] Subsequent `pnpm build` in repo does NOT affect running gateway

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `deploy:local` and `deploy:local:fast` npm scripts to streamline local deployment workflow
  * Fast variant skips testing for quicker development iterations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->