### PR TITLE
scripts: add deploy:replist to re-apply gateway plist after doctor --fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,6 +226,7 @@
     "android:test:integration": "OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_ANDROID_NODE=1 vitest run --config vitest.live.config.ts src/gateway/android-node.capabilities.live.test.ts",
     "deploy:local": "bash scripts/deploy-local.sh",
     "deploy:local:fast": "OPENCLAW_DEPLOY_SKIP_TESTS=1 bash scripts/deploy-local.sh",
+    "deploy:replist": "bash scripts/deploy-replist.sh",
     "build": "pnpm canvas:a2ui:bundle && node scripts/tsdown-build.mjs && node scripts/copy-plugin-sdk-root-alias.mjs && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-startup-metadata.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:docker": "node scripts/tsdown-build.mjs && node scripts/copy-plugin-sdk-root-alias.mjs && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-startup-metadata.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json || true",

--- a/scripts/deploy-replist.sh
+++ b/scripts/deploy-replist.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Authored by: cc (Claude Code) | 2026-03-15
+# Re-apply the ~/.openclaw/dist/index.js gateway plist entry after
+# `openclaw doctor --fix` or `openclaw daemon install` reverts it.
+#
+# Usage:
+#   pnpm deploy:replist
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEPLOY_DIR="${HOME}/.openclaw"
+DIST_DEST="${DEPLOY_DIR}/dist"
+LAUNCHD_LABEL="ai.openclaw.gateway"
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
+DESIRED_ENTRY="${DIST_DEST}/index.js"
+
+log() { printf '[deploy-replist] %s\n' "$*"; }
+
+if [[ ! -f "${PLIST_PATH}" ]]; then
+  log "ERROR: plist not found at ${PLIST_PATH}"
+  exit 1
+fi
+
+if [[ ! -f "${DESIRED_ENTRY}" ]]; then
+  log "ERROR: ${DESIRED_ENTRY} not found — run pnpm deploy:local first"
+  exit 1
+fi
+
+CURRENT_ENTRY="$(/usr/bin/plutil -extract ProgramArguments.1 raw -o - "${PLIST_PATH}" 2>/dev/null || true)"
+
+if [[ "${CURRENT_ENTRY}" == "${DESIRED_ENTRY}" ]]; then
+  log "Plist already correct (${DESIRED_ENTRY}) — nothing to do"
+else
+  log "Reverting plist: ${CURRENT_ENTRY} → ${DESIRED_ENTRY}"
+  launchctl bootout "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null || true
+  /usr/bin/plutil -replace 'ProgramArguments.1' -string "${DESIRED_ENTRY}" "${PLIST_PATH}"
+  log "Plist updated"
+fi
+
+log "Restarting gateway..."
+launchctl bootout "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null || true
+sleep 2
+launchctl bootstrap "gui/$(id -u)" "${PLIST_PATH}"
+sleep 3
+log "Gateway restarted. Checking status..."
+openclaw gateway status --deep || log "WARNING: gateway status check failed — check logs at ${DEPLOY_DIR}/logs/gateway.log"
+
+log "Done. Gateway running from ${DESIRED_ENTRY}"


### PR DESCRIPTION
## Summary
- Adds `scripts/deploy-replist.sh` — re-applies `~/.openclaw/dist/index.js` as the gateway LaunchAgent plist entry after `openclaw doctor --fix` or `openclaw daemon install` reverts it
- Adds `pnpm deploy:replist` npm script

## Problem
`openclaw doctor --fix` rewrites the plist using `process.argv[1]` (the running CLI binary from the repo), silently reverting the `~/.openclaw/dist/index.js` path set by `deploy-local.sh`. This script is the quick fix — no rebuild needed.

## Usage
```bash
pnpm deploy:replist   # re-apply plist + restart gateway
```

## Test plan
- [ ] `chmod +x scripts/deploy-replist.sh`
- [ ] Run `openclaw doctor --fix` to revert plist to repo path
- [ ] `pnpm deploy:replist` — updates plist back to `~/.openclaw/dist/index.js`
- [ ] `openclaw gateway status --deep` passes
- [ ] Re-run `pnpm deploy:replist` with plist already correct — no-op, no crash

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deployment script for gateway configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->