### PR TITLE
refactor(twilio-sms): use subagent.run() SDK instead of runEmbeddedPiAgent

### DIFF
--- a/extensions/twilio-sms/index.ts
+++ b/extensions/twilio-sms/index.ts
@@ -1,4 +1,4 @@
-// Authored by: cc (Claude Code) | 2026-03-18
+// Authored by: cc (Claude Code) | 2026-03-19
 import { Type } from "@sinclair/typebox";
 import type { GatewayRequestHandlerOptions, OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { SmsConfigSchema, resolveSmsConfig, type SmsConfigInput } from "./src/config.js";
@@ -19,7 +19,7 @@ const smsPlugin = {
     api.registerService({
       id: "twilio-sms",
       start: async () => {
-        runtime = await createSmsRuntime(config, api.runtime.agent, api.config, api.logger);
+        runtime = await createSmsRuntime(config, api.runtime.subagent, api.logger);
       },
       stop: async () => {
         await runtime?.stop();

--- a/extensions/twilio-sms/src/runtime.ts
+++ b/extensions/twilio-sms/src/runtime.ts
@@ -1,61 +1,21 @@
-// Authored by: cc (Claude Code) | 2026-03-18
-import crypto from "node:crypto";
+// Authored by: cc (Claude Code) | 2026-03-19
 import http from "node:http";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
-
-type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
-type VerboseLevel = "off" | "on" | "full";
 import { normalizePhoneNumber } from "./allowlist.js";
 import type { SmsConfig } from "./config.js";
 import { handleSmsRequest, type SmsMessage } from "./webhook.js";
 
 const INBOX_MAX = 50;
 
-// Typed against OpenClawPluginApi["runtime"]["agent"] — passed in from index.ts.
-type AgentRuntime = {
-  defaults: { model: string; provider: string };
-  resolveAgentDir: (
-    cfg: OpenClawConfig,
-    agentId: string,
-    env?: Record<string, string | undefined>,
-  ) => string;
-  resolveAgentWorkspaceDir: (cfg: OpenClawConfig, agentId: string) => string;
-  ensureAgentWorkspace: (params: { dir: string }) => Promise<unknown>;
-  resolveAgentIdentity: (cfg: OpenClawConfig, agentId: string) => { name?: string } | undefined;
-  resolveThinkingDefault: (params: {
-    cfg: OpenClawConfig;
-    provider: string;
-    model: string;
-  }) => ThinkLevel;
-  resolveAgentTimeoutMs: (params: { cfg: OpenClawConfig }) => number;
-  session: {
-    resolveStorePath: (store: string | undefined, params: { agentId: string }) => string;
-    loadSessionStore: (path: string) => Record<string, SessionEntry>;
-    saveSessionStore: (path: string, store: Record<string, SessionEntry>) => Promise<void>;
-    resolveSessionFilePath: (
-      sessionId: string,
-      entry?: { sessionFile?: string },
-      params?: { agentId: string },
-    ) => string;
-  };
-  runEmbeddedPiAgent: (params: {
-    sessionId: string;
+// Matches PluginRuntime["subagent"] from src/plugins/runtime/types.ts (v2026.3.13).
+type SubagentRuntime = {
+  run: (params: {
     sessionKey: string;
-    messageProvider: string;
-    sessionFile: string;
-    workspaceDir: string;
-    config: OpenClawConfig;
-    prompt: string;
-    provider: string;
-    model: string;
-    thinkLevel: ThinkLevel;
-    verboseLevel: VerboseLevel;
-    timeoutMs: number;
-    runId: string;
-    lane: string;
-    extraSystemPrompt: string;
-    agentDir: string;
-  }) => Promise<unknown>;
+    message: string;
+    extraSystemPrompt?: string;
+    lane?: string;
+    deliver?: boolean;
+    idempotencyKey?: string;
+  }) => Promise<{ runId: string }>;
 };
 
 type RuntimeLogger = {
@@ -71,8 +31,7 @@ export type SmsRuntime = {
 
 export async function createSmsRuntime(
   config: SmsConfig,
-  agentRuntime: AgentRuntime,
-  coreConfig: OpenClawConfig,
+  subagent: SubagentRuntime,
   logger: RuntimeLogger,
 ): Promise<SmsRuntime> {
   if (!config.skipSignatureVerification && (!config.publicUrl || !config.twilio?.authToken)) {
@@ -94,9 +53,24 @@ export async function createSmsRuntime(
     logger.info(`[twilio-sms] dispatching message to agent (session=${sessionKey})`);
 
     // Fire-and-forget — TwiML response already sent; errors are logged only.
-    dispatchToAgent(msg, sessionKey, agentRuntime, coreConfig, logger).catch((err: unknown) =>
-      logger.error(`[twilio-sms] agent dispatch failed: ${String(err)}`),
-    );
+    subagent
+      .run({
+        sessionKey,
+        message: `SMS from ${msg.from}: ${msg.body}`,
+        extraSystemPrompt:
+          "You are receiving an SMS message. " +
+          `The sender's phone number is ${msg.from}. ` +
+          "Respond helpfully and concisely.",
+        lane: "sms",
+        deliver: false,
+        idempotencyKey: `sms:${msg.messageSid}`,
+      })
+      .then(({ runId }) => {
+        logger.info(`[twilio-sms] agent run dispatched (session=${sessionKey}, runId=${runId})`);
+      })
+      .catch((err: unknown) => {
+        logger.error(`[twilio-sms] agent dispatch failed: ${String(err)}`);
+      });
   };
 
   const server = http.createServer((req, res) => {
@@ -134,78 +108,4 @@ export async function createSmsRuntime(
     // Return a snapshot so callers can't mutate the internal buffer.
     getInbox: () => [...inbox],
   };
-}
-
-type SessionEntry = { sessionId: string; updatedAt: number };
-
-async function dispatchToAgent(
-  msg: SmsMessage,
-  sessionKey: string,
-  agentRuntime: AgentRuntime,
-  cfg: OpenClawConfig,
-  logger: RuntimeLogger,
-): Promise<void> {
-  const agentId = "main";
-
-  const storePath = agentRuntime.session.resolveStorePath(
-    (cfg as { session?: { store?: string } }).session?.store,
-    { agentId },
-  );
-  const agentDir = agentRuntime.resolveAgentDir(cfg, agentId);
-  const workspaceDir = agentRuntime.resolveAgentWorkspaceDir(cfg, agentId);
-  await agentRuntime.ensureAgentWorkspace({ dir: workspaceDir });
-
-  const sessionStore = agentRuntime.session.loadSessionStore(storePath);
-  const now = Date.now();
-  let sessionEntry = sessionStore[sessionKey];
-  if (!sessionEntry) {
-    sessionEntry = { sessionId: crypto.randomUUID(), updatedAt: now };
-    sessionStore[sessionKey] = sessionEntry;
-    await agentRuntime.session.saveSessionStore(storePath, sessionStore);
-  }
-
-  const sessionFile = agentRuntime.session.resolveSessionFilePath(
-    sessionEntry.sessionId,
-    undefined,
-    { agentId },
-  );
-
-  // Read model from config (agents.defaults.model.primary), fall back to SDK defaults.
-  const primaryModel = (cfg as { agents?: { defaults?: { model?: { primary?: string } } } }).agents
-    ?.defaults?.model?.primary;
-  const modelRef =
-    primaryModel || `${agentRuntime.defaults.provider}/${agentRuntime.defaults.model}`;
-  const slashIndex = modelRef.indexOf("/");
-  const provider =
-    slashIndex === -1 ? agentRuntime.defaults.provider : modelRef.slice(0, slashIndex);
-  const model = slashIndex === -1 ? modelRef : modelRef.slice(slashIndex + 1);
-  const thinkLevel = agentRuntime.resolveThinkingDefault({ cfg, provider, model });
-
-  const identity = agentRuntime.resolveAgentIdentity(cfg, agentId);
-  const agentName = identity?.name?.trim() || "assistant";
-  const timeoutMs = agentRuntime.resolveAgentTimeoutMs({ cfg });
-  const runId = `sms:${sessionKey}:${Date.now()}`;
-
-  const extraSystemPrompt = `You are ${agentName}. You are receiving an SMS message. The sender's phone number is ${msg.from}. Respond helpfully and concisely.`;
-
-  await agentRuntime.runEmbeddedPiAgent({
-    sessionId: sessionEntry.sessionId,
-    sessionKey,
-    messageProvider: "sms",
-    sessionFile,
-    workspaceDir,
-    config: cfg,
-    prompt: `SMS from ${msg.from}: ${msg.body}`,
-    provider,
-    model,
-    thinkLevel,
-    verboseLevel: "off",
-    timeoutMs,
-    runId,
-    lane: "sms",
-    extraSystemPrompt,
-    agentDir,
-  });
-
-  logger.info(`[twilio-sms] agent run complete (session=${sessionKey})`);
 }


### PR DESCRIPTION
## Summary

Refactors twilio-sms extension to use `api.runtime.subagent.run()` instead of `api.runtime.agent.runEmbeddedPiAgent`. This makes the extension compatible with v2026.3.13 plugin SDK.

- Replaces ~130 lines of manual session/model/workspace wiring with a single `subagent.run()` call
- Adds `idempotencyKey` (required at 3.13) using Twilio `MessageSid`
- `index.ts`: passes `api.runtime.subagent` instead of `api.runtime.agent`
- `runtime.ts`: simplified from 211 LOC to 111 LOC

## Verified end-to-end

- Gateway starts with Discord + voice-call + twilio-sms
- Inbound SMS webhook receives, verifies signature, checks allowlist
- `subagent.run()` dispatches to agent, agent generates response
- `deliver: false` confirmed — no outbound attempted (Phase 1 inbound-only)

Closes #46

## Test plan

- [x] 28 tests passing (config + webhook)
- [x] Live SMS test verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized SMS message handling with simplified dispatch mechanism and improved idempotency safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->