### PR TITLE
cron: add tests for script payload trimming in normalize

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -464,3 +464,36 @@ describe("normalizeCronJobPatch", () => {
     expect(schedule.staggerMs).toBe(30_000);
   });
 });
+
+describe("coercePayload — script kind trimming", () => {
+  it("trims whitespace from command and cwd", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "trim-test",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      payload: { kind: "script", command: "  ~/scripts/run.sh  ", cwd: "  ~/scripts  " },
+    });
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.command).toBe("~/scripts/run.sh");
+    expect(payload.cwd).toBe("~/scripts");
+  });
+
+  it("removes cwd when whitespace-only", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "blank-cwd",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      payload: { kind: "script", command: "~/scripts/run.sh", cwd: "   " },
+    });
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.cwd).toBeUndefined();
+  });
+
+  it("removes command when whitespace-only", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "blank-cmd",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      payload: { kind: "script", command: "   " },
+    });
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.command).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

The `command`/`cwd` trimming logic in `coercePayload` was already implemented (commit `225c71a72c`) but had no test coverage. This PR adds 3 unit tests:

- Trims whitespace from `command` and `cwd`
- Removes `cwd` when whitespace-only
- Removes `command` when whitespace-only

30/30 tests pass.

Closes #23