### PR TITLE
cron: extract resolveDeliveryConfig + test script delivery flag wiring

### DIFF
--- a/src/cli/cron-cli/register.cron-add.test.ts
+++ b/src/cli/cron-cli/register.cron-add.test.ts
@@ -1,0 +1,94 @@
+// Authored by: cc (Claude Code) | 2026-03-20
+import { describe, expect, it } from "vitest";
+import { resolveDeliveryConfig } from "./register.cron-add.js";
+
+describe("resolveDeliveryConfig — script delivery flags wiring", () => {
+  it("returns announce delivery for script job with --announce", () => {
+    const result = resolveDeliveryConfig({
+      payloadKind: "script",
+      isIsolatedLike: true,
+      hasAnnounce: true,
+      hasNoDeliver: false,
+      channel: "telegram",
+      to: "12345",
+      accountId: "acc1",
+      bestEffortDeliver: true,
+    });
+    expect(result).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "12345",
+      accountId: "acc1",
+      bestEffort: true,
+    });
+  });
+
+  it("returns none delivery for script job with --no-deliver", () => {
+    const result = resolveDeliveryConfig({
+      payloadKind: "script",
+      isIsolatedLike: true,
+      hasAnnounce: false,
+      hasNoDeliver: true,
+    });
+    expect(result).toEqual({
+      mode: "none",
+      channel: undefined,
+      to: undefined,
+      accountId: undefined,
+      bestEffort: undefined,
+    });
+  });
+
+  it("returns undefined for script job without --announce or --no-deliver", () => {
+    const result = resolveDeliveryConfig({
+      payloadKind: "script",
+      isIsolatedLike: true,
+      hasAnnounce: false,
+      hasNoDeliver: false,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for script job when not isolated", () => {
+    const result = resolveDeliveryConfig({
+      payloadKind: "script",
+      isIsolatedLike: false,
+      hasAnnounce: true,
+      hasNoDeliver: false,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for systemEvent regardless of announce flag", () => {
+    const result = resolveDeliveryConfig({
+      payloadKind: "systemEvent",
+      isIsolatedLike: true,
+      hasAnnounce: true,
+      hasNoDeliver: false,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("defaults agentTurn to announce without --announce flag", () => {
+    const result = resolveDeliveryConfig({
+      payloadKind: "agentTurn",
+      isIsolatedLike: true,
+      hasAnnounce: false,
+      hasNoDeliver: false,
+    });
+    expect(result?.mode).toBe("announce");
+  });
+
+  it("trims whitespace from channel and to fields", () => {
+    const result = resolveDeliveryConfig({
+      payloadKind: "script",
+      isIsolatedLike: true,
+      hasAnnounce: true,
+      hasNoDeliver: false,
+      channel: "  telegram  ",
+      to: "  12345  ",
+    });
+    expect(result?.channel).toBe("telegram");
+    expect(result?.to).toBe("12345");
+  });
+});

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -16,6 +16,53 @@ import {
   warnIfCronSchedulerDisabled,
 } from "./shared.js";
 
+type DeliveryConfig = {
+  mode: "announce" | "none";
+  channel?: string;
+  to?: string;
+  accountId?: string;
+  bestEffort?: true;
+};
+
+/**
+ * Resolve the delivery config for a cron job create/edit operation.
+ * Extracted for unit testability — the action handler delegates here.
+ * Returns undefined when delivery is not applicable (systemEvent, no announce).
+ */
+export function resolveDeliveryConfig(opts: {
+  payloadKind: "agentTurn" | "script" | "systemEvent";
+  isIsolatedLike: boolean;
+  hasAnnounce: boolean;
+  hasNoDeliver: boolean;
+  channel?: string;
+  to?: string;
+  accountId?: string;
+  bestEffortDeliver?: boolean;
+}): DeliveryConfig | undefined {
+  const { payloadKind, isIsolatedLike, hasAnnounce, hasNoDeliver } = opts;
+  let mode: "announce" | "none" | undefined;
+  if ((payloadKind === "agentTurn" || payloadKind === "script") && isIsolatedLike) {
+    if (hasAnnounce) {
+      mode = "announce";
+    } else if (hasNoDeliver) {
+      mode = "none";
+    } else if (payloadKind === "agentTurn") {
+      // agentTurn defaults to announce; script requires explicit --announce.
+      mode = "announce";
+    }
+  }
+  if (!mode) {
+    return undefined;
+  }
+  return {
+    mode,
+    channel: opts.channel?.trim() || undefined,
+    to: opts.to?.trim() || undefined,
+    accountId: opts.accountId || undefined,
+    bestEffort: opts.bestEffortDeliver ? true : undefined,
+  };
+}
+
 export function registerCronStatusCommand(cron: Command) {
   addGatewayClientOptions(
     cron
@@ -284,24 +331,19 @@ export function registerCronAddCommand(cron: Command) {
             throw new Error("--account requires a --message or --script job with delivery.");
           }
 
-          // agentTurn defaults to "announce"; script delivery is opt-in (requires --announce).
-          const deliveryMode =
-            payload.kind === "agentTurn" && isIsolatedLikeSessionTarget
-              ? hasAnnounce
-                ? "announce"
-                : hasNoDeliver
-                  ? "none"
-                  : "announce"
-              : payload.kind === "script" && isIsolatedLikeSessionTarget
-                ? hasAnnounce
-                  ? "announce"
-                  : hasNoDeliver
-                    ? "none"
-                    : undefined
-                : undefined;
+          const delivery = resolveDeliveryConfig({
+            payloadKind: payload.kind,
+            isIsolatedLike: isIsolatedLikeSessionTarget,
+            hasAnnounce,
+            hasNoDeliver,
+            channel: typeof opts.channel === "string" ? opts.channel : undefined,
+            to: typeof opts.to === "string" ? opts.to : undefined,
+            accountId,
+            bestEffortDeliver: opts.bestEffortDeliver === true,
+          });
 
           // Delivery-targeting flags only make sense when announce mode is active.
-          if (deliveryMode !== "announce") {
+          if (delivery?.mode !== "announce") {
             const hasExplicitDeliveryFlags =
               (typeof opts.to === "string" && opts.to.trim().length > 0) ||
               Boolean(accountId) ||
@@ -341,18 +383,7 @@ export function registerCronAddCommand(cron: Command) {
             sessionTarget,
             wakeMode,
             payload,
-            delivery: deliveryMode
-              ? {
-                  mode: deliveryMode,
-                  channel:
-                    typeof opts.channel === "string" && opts.channel.trim()
-                      ? opts.channel.trim()
-                      : undefined,
-                  to: typeof opts.to === "string" && opts.to.trim() ? opts.to.trim() : undefined,
-                  accountId,
-                  bestEffort: opts.bestEffortDeliver ? true : undefined,
-                }
-              : undefined,
+            delivery,
           };
 
           const res = await callGatewayFromCli("cron.add", opts, params);


### PR DESCRIPTION
## Summary

The delivery wiring for script jobs was already present but the inline logic was untestable. This PR:

- Extracts the delivery-mode resolution into an exported `resolveDeliveryConfig()` pure function
- Replaces the inline ternary in the Commander action with a call to the helper
- Adds `register.cron-add.test.ts` with 7 unit tests covering:
  - script + `--announce` → delivery object with channel/to/accountId/bestEffort
  - script + `--no-deliver` → `mode: "none"`
  - script with no delivery flags → `undefined`
  - non-isolated script → `undefined`
  - systemEvent always → `undefined`
  - agentTurn defaults to announce
  - field trimming (channel, to)

7/7 tests pass.

Closes #22