### PR TITLE
webchat: add PDF and text file types to attachment file picker

### DIFF
--- a/ui/src/ui/chat/attachment-support.test.ts
+++ b/ui/src/ui/chat/attachment-support.test.ts
@@ -1,0 +1,51 @@
+// Authored by: cc (Claude Code) | 2026-03-20
+import { describe, expect, it } from "vitest";
+import { CHAT_ATTACHMENT_ACCEPT, isSupportedChatAttachmentMimeType } from "./attachment-support.ts";
+
+describe("isSupportedChatAttachmentMimeType", () => {
+  it("accepts image types", () => {
+    expect(isSupportedChatAttachmentMimeType("image/jpeg")).toBe(true);
+    expect(isSupportedChatAttachmentMimeType("image/png")).toBe(true);
+    expect(isSupportedChatAttachmentMimeType("image/webp")).toBe(true);
+    expect(isSupportedChatAttachmentMimeType("image/gif")).toBe(true);
+  });
+
+  it("accepts PDF", () => {
+    expect(isSupportedChatAttachmentMimeType("application/pdf")).toBe(true);
+  });
+
+  it("accepts supported text file types", () => {
+    expect(isSupportedChatAttachmentMimeType("text/plain")).toBe(true);
+    expect(isSupportedChatAttachmentMimeType("text/csv")).toBe(true);
+    expect(isSupportedChatAttachmentMimeType("text/markdown")).toBe(true);
+    expect(isSupportedChatAttachmentMimeType("text/html")).toBe(true);
+    expect(isSupportedChatAttachmentMimeType("application/json")).toBe(true);
+  });
+
+  it("rejects unsupported types", () => {
+    expect(isSupportedChatAttachmentMimeType("application/zip")).toBe(false);
+    expect(isSupportedChatAttachmentMimeType("video/mp4")).toBe(false);
+    expect(isSupportedChatAttachmentMimeType("application/octet-stream")).toBe(false);
+  });
+
+  it("rejects null, undefined, empty string", () => {
+    expect(isSupportedChatAttachmentMimeType(null)).toBe(false);
+    expect(isSupportedChatAttachmentMimeType(undefined)).toBe(false);
+    expect(isSupportedChatAttachmentMimeType("")).toBe(false);
+  });
+});
+
+describe("CHAT_ATTACHMENT_ACCEPT", () => {
+  it("includes image/*", () => {
+    expect(CHAT_ATTACHMENT_ACCEPT).toContain("image/*");
+  });
+
+  it("includes application/pdf", () => {
+    expect(CHAT_ATTACHMENT_ACCEPT).toContain("application/pdf");
+  });
+
+  it("includes text/plain and text/csv", () => {
+    expect(CHAT_ATTACHMENT_ACCEPT).toContain("text/plain");
+    expect(CHAT_ATTACHMENT_ACCEPT).toContain("text/csv");
+  });
+});

--- a/ui/src/ui/chat/attachment-support.ts
+++ b/ui/src/ui/chat/attachment-support.ts
@@ -1,5 +1,20 @@
-export const CHAT_ATTACHMENT_ACCEPT = "image/*";
+// Authored by: cc (Claude Code) | 2026-03-20
+// Matches backend DEFAULT_INPUT_IMAGE_MIMES + DEFAULT_INPUT_FILE_MIMES (src/media/input-files.ts).
+// Keep in sync if backend adds new supported MIME types.
+const SUPPORTED_FILE_MIMES = new Set([
+  "text/plain",
+  "text/markdown",
+  "text/html",
+  "text/csv",
+  "application/json",
+  "application/pdf",
+]);
+
+export const CHAT_ATTACHMENT_ACCEPT = ["image/*", ...SUPPORTED_FILE_MIMES].join(",");
 
 export function isSupportedChatAttachmentMimeType(mimeType: string | null | undefined): boolean {
-  return typeof mimeType === "string" && mimeType.startsWith("image/");
+  if (typeof mimeType !== "string") {
+    return false;
+  }
+  return mimeType.startsWith("image/") || SUPPORTED_FILE_MIMES.has(mimeType);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
       "ui/src/ui/views/usage-render-details.test.ts",
       "ui/src/ui/controllers/agents.test.ts",
       "ui/src/ui/controllers/chat.test.ts",
+      "ui/src/ui/chat/attachment-support.test.ts",
     ],
     setupFiles: ["test/setup.ts"],
     exclude: [


### PR DESCRIPTION
## Summary

- Extends `CHAT_ATTACHMENT_ACCEPT` from `image/*` to also include `application/pdf`, `text/plain`, `text/markdown`, `text/html`, `text/csv`, `application/json`
- Updates `isSupportedChatAttachmentMimeType` to accept the same set (file picker, drag-and-drop, and file select all use this guard)
- MIME list mirrors backend `DEFAULT_INPUT_FILE_MIMES` in `src/media/input-files.ts` — kept in sync via comment
- Adds `attachment-support.test.ts` with 8 unit tests covering accepted types, rejected types, and edge cases
- Registers new test file in `vitest.config.ts` include list

## Test plan

- [ ] `pnpm test -- ui/src/ui/chat/attachment-support.test.ts` passes (8/8)
- [ ] File picker in webchat accepts `.pdf`, `.txt`, `.csv`, `.json` files
- [ ] Images still accepted as before

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded chat attachment support to include PDF files, plain text, Markdown, HTML, CSV, and JSON formats in addition to images.

* **Tests**
  * Added comprehensive test coverage for supported attachment file types and validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->